### PR TITLE
initial stub for querying canopy cover data

### DIFF
--- a/src/trait_data.R
+++ b/src/trait_data.R
@@ -1,0 +1,12 @@
+library(traits)
+options(betydb_key = readLines('~/.betykey', warn = FALSE),
+        betydb_url = "https://terraref.ncsa.illinois.edu/bety/",
+        betydb_api_version = 'beta')
+
+system.time(
+canopy_cover <- betydb_query(table = 'search',
+                               trait = "canopy_cover",
+                               site  = "~Season 6",
+                               limit = '100')
+)
+write.csv(canopy_cover, file = 'data/canopy_cover.csv')


### PR DESCRIPTION
At minimum - need to change `limit=100` to `limit='none'` to get all data. But be aware that this will take a while ...